### PR TITLE
ig - create database table for Articles

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "articles")
+public class Articles {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String title;
+  private String url;
+  private String explanation;
+  private String email;
+  private LocalDateTime localDateTime;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Articles;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RepositoryRestResource(exported = false)
+public interface ArticlesRepository extends CrudRepository<Articles, Long> {}

--- a/src/main/resources/db/migration/changes/Articles.json
+++ b/src/main/resources/db/migration/changes/Articles.json
@@ -1,0 +1,74 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "Articles-1",
+          "author": "ibrahimgok01",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "ARTICLES"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "ARTICLES_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "LOCAL_DATE_TIME",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TITLE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "URL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                        "name": "EXPLANATION",
+                        "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                        "name": "EMAIL",
+                        "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "ARTICLES"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #38 
In this PR, we add a database table for Articles, with these fields:
-
String title
String url
String explanation
String email (of person that submitted it)
LocalDateTime dateAdded
-
You can test this by running on localhost and looking for the Articles table on the h-2 console
You can also test this by running on dokku and connecting to the postgres database and running \dt 