### PR TITLE
Fix UCSBDiningCommonsMenuItem id type and URL casing

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** This is a REST controller for UCSBDiningCommonsMenuItem */
 @Tag(name = "UCSBDiningCommonsMenuItem")
-@RequestMapping("/api/UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/ucsbdiningcommonsmenuitem")
 @RestController
 @Slf4j
 public class UCSBDiningCommonsMenuItemController extends ApiController {
@@ -29,9 +29,9 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
   @Autowired UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
 
   /**
-   * This method returns a list of all UCSBDiningCommonsMenuItems.
+   * List all UCSB dining commons menu items.
    *
-   * @return a list of all UCSBDiningCommonsMenuItems
+   * @return an iterable of UCSBDiningCommonsMenuItem
    */
   @Operation(summary = "List all UCSB dining commons menu items")
   @PreAuthorize("hasRole('ROLE_USER')")
@@ -42,28 +42,26 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
   }
 
   /**
-   * This method returns a single UCSBDiningCommonsMenuItem by its code.
+   * Get a single menu item by id.
    *
-   * @param code code of the menu item
-   * @return the matching UCSBDiningCommonsMenuItem
+   * @param id the id of the menu item
+   * @return a UCSBDiningCommonsMenuItem
    */
   @Operation(summary = "Get a single UCSB dining commons menu item")
   @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("")
-  public UCSBDiningCommonsMenuItem getById(@Parameter(name = "code") @RequestParam String code) {
+  public UCSBDiningCommonsMenuItem getById(@Parameter(name = "id") @RequestParam Long id) {
     UCSBDiningCommonsMenuItem item =
         ucsbDiningCommonsMenuItemRepository
-            .findById(code)
-            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, code));
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
 
     return item;
   }
 
   /**
-   * This method creates a new UCSBDiningCommonsMenuItem. Accessible only to users with the role
-   * "ROLE_ADMIN".
+   * Create a new UCSB dining commons menu item.
    *
-   * @param code unique code identifying the menu item
    * @param diningCommonsCode code for the dining commons that serves the item
    * @param name name of the menu item
    * @param station the station within the dining commons where the item is served
@@ -73,13 +71,11 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PostMapping("/post")
   public UCSBDiningCommonsMenuItem postMenuItem(
-      @Parameter(name = "code") @RequestParam String code,
       @Parameter(name = "diningCommonsCode") @RequestParam String diningCommonsCode,
       @Parameter(name = "name") @RequestParam String name,
       @Parameter(name = "station") @RequestParam String station) {
 
     UCSBDiningCommonsMenuItem item = new UCSBDiningCommonsMenuItem();
-    item.setCode(code);
     item.setDiningCommonsCode(diningCommonsCode);
     item.setName(name);
     item.setStation(station);
@@ -90,9 +86,28 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
   }
 
   /**
-   * Update a single UCSBDiningCommonsMenuItem. Accessible only to users with the role "ROLE_ADMIN".
+   * Delete a UCSBDiningCommonsMenuItem.
    *
-   * @param code code of the menu item to update
+   * @param id the id of the menu item to delete
+   * @return a message indicating the menu item was deleted
+   */
+  @Operation(summary = "Delete a UCSBDiningCommonsMenuItem")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteMenuItem(@Parameter(name = "id") @RequestParam Long id) {
+    UCSBDiningCommonsMenuItem item =
+        ucsbDiningCommonsMenuItemRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+    ucsbDiningCommonsMenuItemRepository.delete(item);
+    return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(id));
+  }
+
+  /**
+   * Update a single UCSBDiningCommonsMenuItem.
+   *
+   * @param id id of the menu item to update
    * @param incoming the new menu item contents
    * @return the updated menu item
    */
@@ -100,13 +115,13 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PutMapping("")
   public UCSBDiningCommonsMenuItem updateMenuItem(
-      @Parameter(name = "code") @RequestParam String code,
+      @Parameter(name = "id") @RequestParam Long id,
       @RequestBody @Valid UCSBDiningCommonsMenuItem incoming) {
 
     UCSBDiningCommonsMenuItem item =
         ucsbDiningCommonsMenuItemRepository
-            .findById(code)
-            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, code));
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
 
     item.setDiningCommonsCode(incoming.getDiningCommonsCode());
     item.setName(incoming.getName());
@@ -115,24 +130,5 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
     ucsbDiningCommonsMenuItemRepository.save(item);
 
     return item;
-  }
-
-  /**
-   * Delete a UCSBDiningCommonsMenuItem. Accessible only to users with the role "ROLE_ADMIN".
-   *
-   * @param code code of the menu item to delete
-   * @return a message indicating the menu item was deleted
-   */
-  @Operation(summary = "Delete a UCSBDiningCommonsMenuItem")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
-  @DeleteMapping("")
-  public Object deleteMenuItem(@Parameter(name = "code") @RequestParam String code) {
-    UCSBDiningCommonsMenuItem item =
-        ucsbDiningCommonsMenuItemRepository
-            .findById(code)
-            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, code));
-
-    ucsbDiningCommonsMenuItemRepository.delete(item);
-    return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(code));
   }
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,6 +1,8 @@
 package edu.ucsb.cs156.example.entities;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +20,10 @@ import lombok.NoArgsConstructor;
 @Builder
 @Entity(name = "ucsbdiningcommonsmenuitem")
 public class UCSBDiningCommonsMenuItem {
-  @Id private String code;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
   private String diningCommonsCode;
   private String name;
   private String station;

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
-/** The UCSBDiningCommonsRepositoryMenuItem is a repository for UCSBDiningCommons entities */
+/**
+ * The UCSBDiningCommonsMenuItemRepository is a repository for UCSBDiningCommonsMenuItem entities
+ */
 @Repository
 @RepositoryRestResource(exported = false)
 public interface UCSBDiningCommonsMenuItemRepository
-    extends CrudRepository<UCSBDiningCommonsMenuItem, String> {}
+    extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -24,12 +24,13 @@
               "columns": [
                 {
                   "column": {
+                    "autoIncrement": true,
                     "constraints": {
                       "primaryKey": true,
                       "primaryKeyName": "UCSBDININGCOMMONSMENUITEM_PK"
                     },
-                    "name": "CODE",
-                    "type": "VARCHAR(255)"
+                    "name": "ID",
+                    "type": "BIGINT"
                   }
                 },
                 {

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -35,17 +35,17 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
   @MockitoBean UserRepository userRepository;
 
-  // Tests for GET /api/UCSBDiningCommonsMenuItem/all
+  // Tests for GET /api/ucsbdiningcommonsmenuitem/all
 
   @Test
   public void logged_out_users_cannot_get_all() throws Exception {
-    mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all")).andExpect(status().is(403));
+    mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all")).andExpect(status().is(403));
   }
 
   @WithMockUser(roles = {"USER"})
   @Test
   public void logged_in_users_can_get_all() throws Exception {
-    mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all")).andExpect(status().is(200));
+    mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all")).andExpect(status().is(200));
   }
 
   @WithMockUser(roles = {"USER"})
@@ -54,31 +54,29 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     // arrange
 
-    UCSBDiningCommonsMenuItem baked_pesto_pasta_with_chicken =
+    UCSBDiningCommonsMenuItem item1 =
         UCSBDiningCommonsMenuItem.builder()
-            .code("BPPC-ORTEGA")
             .diningCommonsCode("ortega")
             .name("Baked Pesto Pasta with Chicken")
             .station("Entree Specials")
             .build();
 
-    UCSBDiningCommonsMenuItem tofu_banh_mi_sandwich =
+    UCSBDiningCommonsMenuItem item2 =
         UCSBDiningCommonsMenuItem.builder()
-            .code("TBMS-ORTEGA")
             .diningCommonsCode("ortega")
             .name("Tofu Banh Mi Sandwich (v)")
             .station("Entree Specials")
             .build();
 
     ArrayList<UCSBDiningCommonsMenuItem> expectedItems = new ArrayList<>();
-    expectedItems.addAll(Arrays.asList(baked_pesto_pasta_with_chicken, tofu_banh_mi_sandwich));
+    expectedItems.addAll(Arrays.asList(item1, item2));
 
     when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedItems);
 
     // act
     MvcResult response =
         mockMvc
-            .perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+            .perform(get("/api/ucsbdiningcommonsmenuitem/all"))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -90,12 +88,12 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
     assertEquals(expectedJson, responseString);
   }
 
-  // Tests for GET /api/UCSBDiningCommonsMenuItem?code=...
+  // Tests for GET /api/ucsbdiningcommonsmenuitem?id=...
 
   @Test
   public void logged_out_users_cannot_get_by_id() throws Exception {
     mockMvc
-        .perform(get("/api/UCSBDiningCommonsMenuItem").param("code", "BPPC-ORTEGA"))
+        .perform(get("/api/ucsbdiningcommonsmenuitem").param("id", "7"))
         .andExpect(status().is(403));
   }
 
@@ -107,25 +105,23 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     UCSBDiningCommonsMenuItem item =
         UCSBDiningCommonsMenuItem.builder()
-            .code("BPPC-ORTEGA")
             .diningCommonsCode("ortega")
             .name("Baked Pesto Pasta with Chicken")
             .station("Entree Specials")
             .build();
 
-    when(ucsbDiningCommonsMenuItemRepository.findById(eq("BPPC-ORTEGA")))
-        .thenReturn(Optional.of(item));
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(item));
 
     // act
     MvcResult response =
         mockMvc
-            .perform(get("/api/UCSBDiningCommonsMenuItem").param("code", "BPPC-ORTEGA"))
+            .perform(get("/api/ucsbdiningcommonsmenuitem").param("id", "7"))
             .andExpect(status().isOk())
             .andReturn();
 
     // assert
 
-    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq("BPPC-ORTEGA"));
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
     String expectedJson = mapper.writeValueAsString(item);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
@@ -137,32 +133,30 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     // arrange
 
-    when(ucsbDiningCommonsMenuItemRepository.findById(eq("nope-ortega")))
-        .thenReturn(Optional.empty());
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
     // act
     MvcResult response =
         mockMvc
-            .perform(get("/api/UCSBDiningCommonsMenuItem").param("code", "nope-ortega"))
+            .perform(get("/api/ucsbdiningcommonsmenuitem").param("id", "7"))
             .andExpect(status().isNotFound())
             .andReturn();
 
     // assert
 
-    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq("nope-ortega"));
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("UCSBDiningCommonsMenuItem with id nope-ortega not found", json.get("message"));
+    assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
   }
 
-  // Tests for POST /api/UCSBDiningCommonsMenuItem/post
+  // Tests for POST /api/ucsbdiningcommonsmenuitem/post
 
   @Test
   public void logged_out_users_cannot_post() throws Exception {
     mockMvc
         .perform(
-            post("/api/UCSBDiningCommonsMenuItem/post")
-                .param("code", "BPPC-ORTEGA")
+            post("/api/ucsbdiningcommonsmenuitem/post")
                 .param("diningCommonsCode", "ortega")
                 .param("name", "Baked Pesto Pasta with Chicken")
                 .param("station", "Entree Specials")
@@ -175,8 +169,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
   public void logged_in_regular_users_cannot_post() throws Exception {
     mockMvc
         .perform(
-            post("/api/UCSBDiningCommonsMenuItem/post")
-                .param("code", "BPPC-ORTEGA")
+            post("/api/ucsbdiningcommonsmenuitem/post")
                 .param("diningCommonsCode", "ortega")
                 .param("name", "Baked Pesto Pasta with Chicken")
                 .param("station", "Entree Specials")
@@ -191,7 +184,6 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     UCSBDiningCommonsMenuItem item =
         UCSBDiningCommonsMenuItem.builder()
-            .code("BPPC-ORTEGA")
             .diningCommonsCode("ortega")
             .name("Baked Pesto Pasta with Chicken")
             .station("Entree Specials")
@@ -203,8 +195,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
     MvcResult response =
         mockMvc
             .perform(
-                post("/api/UCSBDiningCommonsMenuItem/post")
-                    .param("code", "BPPC-ORTEGA")
+                post("/api/ucsbdiningcommonsmenuitem/post")
                     .param("diningCommonsCode", "ortega")
                     .param("name", "Baked Pesto Pasta with Chicken")
                     .param("station", "Entree Specials")
@@ -219,7 +210,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
     assertEquals(expectedJson, responseString);
   }
 
-  // Tests for PUT /api/UCSBDiningCommonsMenuItem?code=...
+  // Tests for PUT /api/ucsbdiningcommonsmenuitem?id=...
 
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
@@ -228,7 +219,6 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     UCSBDiningCommonsMenuItem original =
         UCSBDiningCommonsMenuItem.builder()
-            .code("BPPC-ORTEGA")
             .diningCommonsCode("ortega")
             .name("Baked Pesto Pasta with Chicken")
             .station("Entree Specials")
@@ -236,7 +226,6 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     UCSBDiningCommonsMenuItem edited =
         UCSBDiningCommonsMenuItem.builder()
-            .code("BPPC-ORTEGA")
             .diningCommonsCode("portola")
             .name("Baked Pesto Pasta")
             .station("Greens & Grains")
@@ -244,15 +233,14 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     String requestBody = mapper.writeValueAsString(edited);
 
-    when(ucsbDiningCommonsMenuItemRepository.findById(eq("BPPC-ORTEGA")))
-        .thenReturn(Optional.of(original));
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(original));
 
     // act
     MvcResult response =
         mockMvc
             .perform(
-                put("/api/UCSBDiningCommonsMenuItem")
-                    .param("code", "BPPC-ORTEGA")
+                put("/api/ucsbdiningcommonsmenuitem")
+                    .param("id", "7")
                     .contentType(MediaType.APPLICATION_JSON)
                     .characterEncoding("utf-8")
                     .content(requestBody)
@@ -261,7 +249,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
             .andReturn();
 
     // assert
-    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById("BPPC-ORTEGA");
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(7L);
     verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(edited);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(requestBody, responseString);
@@ -274,7 +262,6 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     UCSBDiningCommonsMenuItem editedItem =
         UCSBDiningCommonsMenuItem.builder()
-            .code("nope-ortega")
             .diningCommonsCode("ortega")
             .name("Imaginary Item")
             .station("Nowhere")
@@ -282,15 +269,14 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     String requestBody = mapper.writeValueAsString(editedItem);
 
-    when(ucsbDiningCommonsMenuItemRepository.findById(eq("nope-ortega")))
-        .thenReturn(Optional.empty());
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
     // act
     MvcResult response =
         mockMvc
             .perform(
-                put("/api/UCSBDiningCommonsMenuItem")
-                    .param("code", "nope-ortega")
+                put("/api/ucsbdiningcommonsmenuitem")
+                    .param("id", "7")
                     .contentType(MediaType.APPLICATION_JSON)
                     .characterEncoding("utf-8")
                     .content(requestBody)
@@ -299,12 +285,12 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
             .andReturn();
 
     // assert
-    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById("nope-ortega");
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(7L);
     Map<String, Object> json = responseToJson(response);
-    assertEquals("UCSBDiningCommonsMenuItem with id nope-ortega not found", json.get("message"));
+    assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
   }
 
-  // Tests for DELETE /api/UCSBDiningCommonsMenuItem?code=...
+  // Tests for DELETE /api/ucsbdiningcommonsmenuitem?id=...
 
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
@@ -313,29 +299,26 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     UCSBDiningCommonsMenuItem item =
         UCSBDiningCommonsMenuItem.builder()
-            .code("BPPC-ORTEGA")
             .diningCommonsCode("ortega")
             .name("Baked Pesto Pasta with Chicken")
             .station("Entree Specials")
             .build();
 
-    when(ucsbDiningCommonsMenuItemRepository.findById(eq("BPPC-ORTEGA")))
-        .thenReturn(Optional.of(item));
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(item));
 
     // act
     MvcResult response =
         mockMvc
-            .perform(
-                delete("/api/UCSBDiningCommonsMenuItem").param("code", "BPPC-ORTEGA").with(csrf()))
+            .perform(delete("/api/ucsbdiningcommonsmenuitem").param("id", "7").with(csrf()))
             .andExpect(status().isOk())
             .andReturn();
 
     // assert
-    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById("BPPC-ORTEGA");
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(7L);
     verify(ucsbDiningCommonsMenuItemRepository, times(1)).delete(any());
 
     Map<String, Object> json = responseToJson(response);
-    assertEquals("UCSBDiningCommonsMenuItem with id BPPC-ORTEGA deleted", json.get("message"));
+    assertEquals("UCSBDiningCommonsMenuItem with id 7 deleted", json.get("message"));
   }
 
   @WithMockUser(roles = {"ADMIN", "USER"})
@@ -344,20 +327,18 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
       throws Exception {
     // arrange
 
-    when(ucsbDiningCommonsMenuItemRepository.findById(eq("nope-ortega")))
-        .thenReturn(Optional.empty());
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
     // act
     MvcResult response =
         mockMvc
-            .perform(
-                delete("/api/UCSBDiningCommonsMenuItem").param("code", "nope-ortega").with(csrf()))
+            .perform(delete("/api/ucsbdiningcommonsmenuitem").param("id", "7").with(csrf()))
             .andExpect(status().isNotFound())
             .andReturn();
 
     // assert
-    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById("nope-ortega");
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(7L);
     Map<String, Object> json = responseToJson(response);
-    assertEquals("UCSBDiningCommonsMenuItem with id nope-ortega not found", json.get("message"));
+    assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
   }
 }


### PR DESCRIPTION
Switches the menu item table to an auto-generated Long id and the lowercase /api/ucsbdiningcommonsmenuitem URL convention used by the rest of the controllers (was String code and /api/UCSBDiningCommonsMenuItem).